### PR TITLE
PUP-9238

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,16 @@ _Default: undef_
 
 The password for the user to run the Puppet run scheduled task as. Only used if specifying a user other than "system".
 
+#### `puppet_run_scheduler::windows::manage_lastrun_acls`
+
+_Default: true_
+
+Whether or not to manage acl entries on Puppet lastrun files, to work around [PUP-9238](https://tickets.puppetlabs.com/browse/PUP-9238).
+
 ## Known Issues
+
+See https://tickets.puppetlabs.com/browse/PUP-9238.
 
 On Windows, when running from a Scheduled Task, Puppet creates cache files that are not readable by "Everyone", only SYSTEM. This has the effect of making manual `puppet agent -t` runs return a lot of red text in the shell. The last line of red text even suggests that Puppet was unable to submit a report. This isn't true though; Puppet DOES submit a report.
 
-A fix will need to discover why the cache files are created with the permissions that they are, and implement some change to ensure the files are readable by at least the local administrators group.
+A workaround exists in the module to avoid this by explicitly ensuring minimal ACEs exist on those files.

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -10,6 +10,7 @@ class puppet_run_scheduler::windows (
   String                            $scheduled_task_user     = 'system',
   Variant[Undef, String, Sensitive] $scheduled_task_password = undef,
   String[1]                         $puppet_executable       = 'C:\\Program Files\\Puppet Labs\\Puppet\\bin\\puppet.bat',
+  Boolean                           $manage_lastrun_acls     = true,
 ) {
   assert_private()
 
@@ -30,6 +31,36 @@ class puppet_run_scheduler::windows (
       'start_time'       => sprintf('%02d:%02d', $start_hour, $start_min),
       'minutes_interval' => $interval_mins,
     }],
+  }
+
+  # https://tickets.puppetlabs.com/browse/PUP-9238
+  # On Windows, the lastrun files are currently not created with appropriate
+  # directory inherited acls. Lastrun files created when Puppet is run from a
+  # scheduled task will have improper ACLs that will prevent Puppet from
+  # finishing a manually invoked run correctly. Therefore, ensure during the
+  # Puppet run that ACLs on these files are set correctly.
+  if $manage_lastrun_acls {
+    $statedir = 'C:/ProgramData/PuppetLabs/puppet/cache/state'
+    $lastrun_files = {
+      'puppet-lastrunfile'   => "${statedir}/last_run_summary.yaml",
+      'puppet-lastrunreport' => "${statedir}/last_run_report.yaml",
+    }
+
+    $lastrun_files.each |$title, $path| {
+      file { $title:
+        ensure => file,
+        path   => $path,
+      }
+
+      acl { $title:
+        target      => $path,
+        purge       => false,
+        permissions => [
+          {'identity' => 'BUILTIN\Administrators', 'rights' => ['full']},
+          {'identity' => 'NT AUTHORITY\SYSTEM', 'rights' => ['full']},
+        ],
+      }
+    }
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/reidmv/reidmv-puppet_run_scheduler",
   "issues_url": "https://github.com/reidmv/reidmv-puppet_run_scheduler/issues",
   "dependencies": [
-
+    { "name":"puppetlabs/acl","version_requirement":">= 2.0.1 < 3.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
On Windows, the lastrun files are currently not created with appropriate
directory inherited acls. Lastrun files created when Puppet is run from a
scheduled task will have improper ACLs that will prevent Puppet from
finishing a manually invoked run correctly. Therefore, ensure during the
Puppet run that ACLs on these files are set correctly.

https://tickets.puppetlabs.com/browse/PUP-9238