### PR TITLE
Expose executable param, fix testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,8 +3,5 @@
 ---
 fixtures:
   forge_modules:
-#     stdlib: "puppetlabs/stdlib"
-fixtures:
-   forge_modules:
-     acl: "puppetlabs/acl"
-     scheduled_task: "puppetlabs/scheduled_task"
+    acl: "puppetlabs/acl"
+    scheduled_task: "puppetlabs/scheduled_task"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,10 +7,12 @@
 # @example
 #   include puppet_run_scheduler
 class puppet_run_scheduler (
-  Enum['present', 'absent']          $ensure       = 'present',
-  Puppet_run_scheduler::Run_interval $run_interval = '30m',
-  Pattern[/[0-2]\d:\d\d/]            $start_time   = '00:00',
-  Puppet_run_scheduler::Run_interval $splaylimit   = $run_interval,
+  Enum['present', 'absent']          $ensure                    = 'present',
+  Puppet_run_scheduler::Run_interval $run_interval              = '30m',
+  Pattern[/[0-2]\d:\d\d/]            $start_time                = '00:00',
+  Puppet_run_scheduler::Run_interval $splaylimit                = $run_interval,
+  String[1]                          $posix_puppet_executable   = '/opt/puppetlabs/bin/puppet',
+  String[1]                          $windows_puppet_executable = 'C:\\Program Files\\Puppet Labs\\Puppet\\bin\\puppet.bat',
 ) {
   $interval_mins = puppet_run_scheduler::minutes($run_interval)
   $splaylimit_mins = puppet_run_scheduler::minutes($splaylimit)

--- a/manifests/posix.pp
+++ b/manifests/posix.pp
@@ -7,10 +7,9 @@
 # @example
 #   include puppet_run_scheduler::posix
 class puppet_run_scheduler::posix (
-  String[1] $puppet_executable = '/opt/puppetlabs/bin/puppet',
+  String[1] $puppet_executable = $puppet_run_scheduler::posix_puppet_executable,
 ) {
   assert_private()
-  include(puppet_run_scheduler)
 
   $interval_mins = $puppet_run_scheduler::interval_mins
   $runs_per_day  = $puppet_run_scheduler::runs_per_day

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -9,11 +9,10 @@
 class puppet_run_scheduler::windows (
   String                            $scheduled_task_user     = 'system',
   Variant[Undef, String, Sensitive] $scheduled_task_password = undef,
-  String[1]                         $puppet_executable       = 'C:\\Program Files\\Puppet Labs\\Puppet\\bin\\puppet.bat',
+  String[1]                         $puppet_executable       = $puppet_run_scheduler::windows_puppet_executable,
   Boolean                           $manage_lastrun_acls     = true,
 ) {
   assert_private()
-  include(puppet_run_scheduler)
 
   $interval_mins = $puppet_run_scheduler::interval_mins
   $start_hour    = $puppet_run_scheduler::start_hour

--- a/spec/classes/posix_spec.rb
+++ b/spec/classes/posix_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'puppet_run_scheduler::posix' do
   let(:pre_condition) do
     # This mocks the assert_private() function so that private classes may be tested
-    'function assert_private() { }'
+    'include puppet_run_scheduler
+    function assert_private() { }'
   end
 
   test_on = {supported_os: [{'operatingsystem' => 'CentOS'},

--- a/spec/classes/windows_spec.rb
+++ b/spec/classes/windows_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'puppet_run_scheduler::windows' do
   let(:pre_condition) do
     # This mocks the assert_private() function so that private classes may be tested
-    'function assert_private() { }'
+    'include puppet_run_scheduler
+    function assert_private() { }'
   end
 
   test_on = {supported_os: [{'operatingsystem' => 'windows'}]}


### PR DESCRIPTION
This allows the puppet_executable for both posix and windows to be set via the class declaration which, in turn, facilitates this module being used within another module.

A change is also included that removed an unneeded include line recently added to the posix and windows files and, instead, puppet_run_scheduler is included in each class's preconditions.