### PR TITLE
Fix ordering of acl permissions

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -83,8 +83,8 @@ class puppet_run_scheduler::windows (
         purge                      => false,
         inherit_parent_permissions => false,
         permissions                => [
-          { 'identity' => 'BUILTIN\Administrators', 'rights' => ['full'] },
           { 'identity' => 'NT AUTHORITY\SYSTEM', 'rights' => ['full'] },
+          { 'identity' => 'BUILTIN\Administrators', 'rights' => ['full'] },
         ],
       }
     }


### PR DESCRIPTION
It seems the ordering of permissions in the acl resource matters, because every puppet run results in:

```powershell
Notice: /Stage[main]/Puppet_run_scheduler::Windows/Acl[puppet-lastrunreport]/permissions: permissions changed [{"identity"=>"NT AUTHORITY\\SYSTEM", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"BUILTIN\\Administrators", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"VEEAM-AP-PROD-1\\Administrator", "rights"=>["full"], "affects"=>:self_only}] to [{"identity"=>"BUILTIN\\Administrators", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"NT AUTHORITY\\SYSTEM", "rights"=>["full"], "affects"=>:self_only}, {"identity"=>"VEEAM-AP-PROD-1\\Administrator", "rights"=>["full"], "affects"=>:self_only}]
```

This fixes that issue.