### PR TITLE
Using SID instead of "display" name doesn't break for Windows ACL groups

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -84,7 +84,7 @@ class puppet_run_scheduler::windows (
         inherit_parent_permissions => false,
         permissions                => [
           { 'identity' => 'NT AUTHORITY\SYSTEM', 'rights' => ['full'] },
-          { 'identity' => 'BUILTIN\Administrators', 'rights' => ['full'] },
+          { 'identity' => 'S-1-5-32-544', 'rights' => ['full'] },
         ],
       }
     }


### PR DESCRIPTION
Windows systems that have been set up with an image with a base language that is not English will not have BUILTIN\Administrators but localised groups instead. Language packs will not fix this, this will stay forever.

However, Microsoft also uses well-known SIDs, this group among them, which we can use independent of any localisation (see: https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids).

This code will fix issue https://github.com/reidmv/reidmv-puppet_run_scheduler/issues/7 for non-US systems (thanks for the hint, Dominik!)