### PR TITLE
Update metadata.json (project information, PDK)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
-  "name": "reidmv-puppet_run_scheduler",
+  "name": "puppet-puppet_run_scheduler",
   "version": "1.0.2",
-  "author": "Reid Vandewiele",
+  "author": "Vox Pupuli",
   "summary": "Configure and distribute Puppet run frequency using Cron (Posix) and Scheduled Tasks (Windows)",
   "license": "Apache-2.0",
-  "source": "https://github.com/reidmv/reidmv-puppet_run_scheduler.git",
-  "project_page": "https://github.com/reidmv/reidmv-puppet_run_scheduler",
-  "issues_url": "https://github.com/reidmv/reidmv-puppet_run_scheduler/issues",
+  "source": "https://github.com/voxpupuli/puppet-puppet_run_scheduler.git",
+  "project_page": "https://github.com/voxpupuli/puppet-puppet_run_scheduler",
+  "issues_url": "https://github.com/voxpupuli/puppet-puppet_run_scheduler/issues",
   "dependencies": [
     {
       "name": "puppetlabs/acl",
@@ -97,8 +97,5 @@
       "name": "openvox",
       "version_requirement": ">= 8.19.0 < 9.0.0"
     }
-  ],
-  "pdk-version": "2.1.0",
-  "template-url": "pdk-default#2.1.0",
-  "template-ref": "tags/2.1.0-0-ga675ea5"
+  ]
 }


### PR DESCRIPTION
metadata.json had outdated information:

- The project's new home is Vox Pupuli now
- Dropping PDK information